### PR TITLE
Correct 'one' to 'once'

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ If you'd like to preview the theme locally (for example, in the process of propo
 
 ### Running tests
 
-The theme contains a minimal test suite, to ensure a site with the theme would build successfully. To run the tests, simply run `script/cibuild`. You'll need to run `script/bootstrap` one before the test script will work.
+The theme contains a minimal test suite, to ensure a site with the theme would build successfully. To run the tests, simply run `script/cibuild`. You'll need to run `script/bootstrap` once before the test script will work.


### PR DESCRIPTION
Just a simple spelling correction.