### PR TITLE
Add GitHub's `kbd` styles

### DIFF
--- a/_sass/jekyll-theme-cayman.scss
+++ b/_sass/jekyll-theme-cayman.scss
@@ -182,6 +182,20 @@ a {
     padding: 2rem 1rem;
     font-size: 1rem;
   }
+  
+  kbd {
+    background-color: #fafbfc;
+    border: 1px solid #c6cbd1;
+    border-bottom-color: #959da5;
+    border-radius: 3px;
+    box-shadow: inset 0 -1px 0 #959da5;
+    color: #444d56;
+    display: inline-block;
+    font-size: 11px;
+    line-height: 10px;
+    padding: 3px 5px;
+    vertical-align: middle;
+  }
 
   img {
     max-width: 100%;


### PR DESCRIPTION
### In github markdown preview it looks like that: [Link](https://github.com/gebeto/info/blob/master/kbd.md)
![screen shot 2019-01-26 at 12 53 48 am](https://user-images.githubusercontent.com/13422799/51777291-1e650200-2105-11e9-8587-3e070327ba3b.png)

### But on `github pages` it looks bad: [Link](https://gebeto.github.io/info/kbd)
![screen shot 2019-01-26 at 12 54 07 am](https://user-images.githubusercontent.com/13422799/51777404-ac40ed00-2105-11e9-9f20-359e82ff8568.png)


### It is result with my fix:
![screen shot 2019-01-26 at 12 58 05 am](https://user-images.githubusercontent.com/13422799/51777413-b06d0a80-2105-11e9-8a11-38aa06c1c63e.png)
