### PR TITLE
Allow per-page title and description with Front Matter

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,8 +23,8 @@
     <a id="skip-to-content" href="#content">Skip to the content.</a>
 
     <header class="page-header" role="banner">
-      <h1 class="project-name">{{ site.title | default: site.github.repository_name }}</h1>
-      <h2 class="project-tagline">{{ site.description | default: site.github.project_tagline }}</h2>
+      <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
+      <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
       {% if site.github.is_project_page %}
         <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
       {% endif %}

--- a/another-page.md
+++ b/another-page.md
@@ -1,5 +1,7 @@
 ---
 layout: default
+title: Another page
+description: This is just another page
 ---
 
 ## Welcome to another page


### PR DESCRIPTION
Currently, every page shares one identical title and tagline as specified in `_config.yml`. This patch allows each page to have its own title and tagline by specifying them in Jekyll front matter:

Here's a simple demo (the change is committed in this PR):

```
---
layout: default
title: Another page
description: This is just another page
---

## Welcome to another page

_yay_

[back](./)
```

![image](https://user-images.githubusercontent.com/7273074/52520942-b2f56580-2caa-11e9-8d18-2162ca448929.png)
