### PR TITLE
Remove code text color

### DIFF
--- a/_sass/jekyll-theme-cayman.scss
+++ b/_sass/jekyll-theme-cayman.scss
@@ -221,7 +221,6 @@ a {
     padding: 2px 4px;
     font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
     font-size: 0.9rem;
-    color: $code-text-color;
     background-color: $code-bg-color;
     border-radius: 0.3rem;
   }
@@ -231,7 +230,6 @@ a {
     margin-top: 0;
     margin-bottom: 1rem;
     font: 1rem Consolas, "Liberation Mono", Menlo, Courier, monospace;
-    color: $code-text-color;
     word-wrap: normal;
     background-color: $code-bg-color;
     border: solid 1px $border-color;
@@ -241,7 +239,6 @@ a {
       padding: 0;
       margin: 0;
       font-size: 0.9rem;
-      color: $code-text-color;
       word-break: normal;
       white-space: pre;
       background: transparent;


### PR DESCRIPTION
This fixes an upstream bug as reported in https://github.com/jasonlong/cayman-theme/issues/26 and fixed in https://github.com/jasonlong/cayman-theme/issues/27.

I've simply removed the color for code blocks since it's not all that different than the default color and it interferes with having links appear blue when inside code blocks.