### PR TITLE
Update SUPPORT.md

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -2,8 +2,8 @@
 
 If you think you've found a bug in The Cayman Theme, please [check the existing issues](https://github.com/pages-themes/cayman/issues), and if no one has reported the problem, [open a new issue](https://github.com/pages-themes/cayman/issues/new).
 
-If you have a general question about the theme, how to implement it, or how to customize it for your site  you have two options:
+If you have a general question about the theme, how to implement it, or how to customize it for your site  you have a few options:
 
-1. [Contact GitHub Support](https://github.com/contact?form%5Bsubject%5D=GitHub%20Pages%20theme%20pages-themes/cayman), or
-
+1. Search for your query on [`support.github.com`](https://support.github.com/?q=pages+themes+cayman), which will also look for similar topics on [`github.community`](https://github.community/)
 2. Ask your question of the Jekyll community on [talk.jekyllrb.com](https://talk.jekyllrb.com/)
+3. [Contact GitHub Support](https://github.com/contact?form%5Bsubject%5D=GitHub%20Pages%20theme%20pages-themes/cayman)


### PR DESCRIPTION
Updates the existing support document to point to the new `support.github.com` as well as `github.community`. I'll also update all the rest of the repos in this Org once we're 👍 on the general wording here.

cc @pages-themes/maintainers 