### PR TITLE
Optimize fonts loading

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,8 @@
     <meta charset="UTF-8">
 
 {% seo %}
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link rel="preload" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap" as="style" type="text/css" crossorigin>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/_sass/jekyll-theme-cayman.scss
+++ b/_sass/jekyll-theme-cayman.scss
@@ -1,7 +1,7 @@
 @import "normalize";
 @import "rouge-github";
 @import "variables";
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,700');
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap');
 
 @mixin large {
   @media screen and (min-width: #{$large-breakpoint}) {

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,7 +3,7 @@
 set -e
 
 bundle exec jekyll build
-bundle exec htmlproofer ./_site --check-html --check-sri
+bundle exec htmlproofer ./_site --check-html --check-sri --uri-ignore "https://fonts.gstatic.com"
 bundle exec rubocop -D
 bundle exec script/validate-html
 gem build jekyll-theme-cayman.gemspec

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,7 +3,7 @@
 set -e
 
 bundle exec jekyll build
-bundle exec htmlproofer ./_site --check-html --check-sri --uri-ignore "https://fonts.gstatic.com"
+bundle exec htmlproofer ./_site --check-html --check-sri --url-ignore "https://fonts.gstatic.com"
 bundle exec rubocop -D
 bundle exec script/validate-html
 gem build jekyll-theme-cayman.gemspec


### PR DESCRIPTION
- Use `font-display: swap`
- Preload Google Fonts CSS
- Add Google Fonts URL to ignore by `htmlproofer`, to avoid false positive