### PR TITLE
Add support for Google AdSense

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Additionally, you may choose to set the following optional variables:
 ```yml
 show_downloads: ["true" or "false" to indicate whether to provide a download URL]
 google_analytics: [Your Google Analytics tracking ID]
+google_adsense: [Your Google data-ad-client ID]
 ```
 
 ### Stylesheet

--- a/_config.yml
+++ b/_config.yml
@@ -2,4 +2,5 @@ title: Cayman theme
 description: Cayman is a clean, responsive theme for GitHub Pages.
 show_downloads: true
 google_analytics:
+google_adsense:
 theme: jekyll-theme-cayman

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>
-
+    {% if site.google_adsense %}
+      <script data-ad-client="{{ site.google_adsense }}" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"</script>
+    {% endif %}
     {% if site.google_analytics %}
       <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
       <script>


### PR DESCRIPTION
The Google AdSense `data-ad-client` ID can be defined in the `_config.yml` file as a value for `google_adsense:` and it will be natively supported. 

Note: I'm not sure if the `async src` is static. If it isn't this commit won't be enough.