### PR TITLE
Edit styling of table element

### DIFF
--- a/_sass/jekyll-theme-cayman.scss
+++ b/_sass/jekyll-theme-cayman.scss
@@ -313,15 +313,51 @@ a {
     word-break: normal;
     word-break: keep-all; // For Firefox to horizontally scroll wider tables.
     -webkit-overflow-scrolling: touch;
+    border-collapse: separate;
 
     th {
       font-weight: bold;
+      background-color: $section-headings-color;
+      border-top: 1px solid $table-border-color;
+      color: #fff;
+
+      &:first-child {
+        border-top-left-radius: 8px;
+      }
+
+      &:last-child {
+        border-top-right-radius: 8px;
+      }
+    }
+
+    tr {
+      &:nth-child(even) {
+        background-color: #f5f9f7; // lighten $section-headings-color
+      }
+
+      &:last-child {
+        td:first-child {
+          border-bottom-left-radius: 8px;
+        }
+
+        td:last-child {
+          border-bottom-right-radius: 8px;
+        }
+      }
     }
 
     th,
     td {
       padding: 0.5rem 1rem;
-      border: 1px solid $table-border-color;
+      border-bottom: 1px solid $table-border-color;
+
+      &:first-child {
+        border-left: 1px solid $table-border-color;
+      }
+
+      &:last-child {
+        border-right: 1px solid $table-border-color;
+      }
     }
   }
 


### PR DESCRIPTION
I've endeavoured to make as few changes to the behaviour/ structure of `table` as possible while giving it a more modern look.

I've used the variable `$section-headings-color`, and a modified version for the even table rows `#159957` -> `#f5f9f7` (comment mentioning this in the theme's scss file). Not sure what the most appropriate solution with these colours is. Does anyone have any suggestions?

I've also toyed with this other combination: `#157a76` -> `#f5faf6`, the former is a colour from the middle-ish of `.page-header`s `linear-gradient`. This has a nice teal effect, and differentiates it from the heading colour, yet is still aligned with the theme. If these colours are preferred, I'll amend my commit to pop them in `variables.scss` :)

### Before
<img width="436" alt="Screenshot 2021-01-27 at 13 48 50" src="https://user-images.githubusercontent.com/27422045/106001290-ab9e1100-60a7-11eb-91b6-439dff4c4b0a.png">

### After

<img width="433" alt="Screenshot 2021-01-27 at 13 48 58" src="https://user-images.githubusercontent.com/27422045/106001301-ae006b00-60a7-11eb-85c9-fc1e5d989423.png">
