### PR TITLE
Add _sass/cayman.scss to allow importing with theme name while using jekyll-remote-theme

### DIFF
--- a/_sass/cayman.scss
+++ b/_sass/cayman.scss
@@ -1,0 +1,4 @@
+// Placeholder file. If your site uses
+//     @import "{{ site.theme }}";
+// Then using this theme with jekyll-remote-theme will work fine.
+@import "jekyll-theme-cayman";

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,7 +3,7 @@
 set -e
 
 bundle exec jekyll build
-bundle exec htmlproofer ./_site --check-html --check-sri
+bundle exec htmlproofer ./_site --check-html --check-sri --url-ignore '/fonts.gstatic.com/'
 bundle exec rubocop -D --config .rubocop.yml
 bundle exec script/validate-html
 gem build jekyll-theme-cayman.gemspec


### PR DESCRIPTION
Allows use of `@import {{site.theme}}` when you have `remote_theme: pages-theme/cayman@v0.2.0` in your `_config.yml`.