### PR TITLE
Add OpenGraph prefix

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: "en-US" }}">
+<html lang="{{ site.lang | default: "en-US" }}" prefix="og: https://ogp.me/ns#">
   <head>
     <meta charset="UTF-8">
 


### PR DESCRIPTION
Adds the OpenGraph prefix to enable the use of additional OpenGraph tags in [head-custom.html](https://github.com/pages-themes/cayman/blob/master/_includes/head-custom.html)