### PR TITLE
Added Google Tag Manager support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: script/cibuild
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ _site
 Gemfile.lock
 *.gem
 .jekyll-cache
-.jekyll-cache
+.vscode

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Additionally, you may choose to set the following optional variables:
 ```yml
 show_downloads: ["true" or "false" (unquoted) to indicate whether to provide a download URL]
 google_analytics: [Your Google Analytics tracking ID]
+google_tag: [Your Google Tag Manager ID]
 ```
 
 ### Stylesheet
@@ -71,6 +72,8 @@ If you'd like to change the theme's HTML layout:
 ### Customizing Google Analytics code
 
 Google has released several iterations to their Google Analytics code over the years since this theme was first created. If you would like to take advantage of the latest code, paste it into `_includes/head-custom-google-analytics.html` in your Jekyll site.
+
+You may now also use the [Google Tag Manager](https://tagmanager.google.com/) to install and configure the latest analytics code.
 
 ### Overriding GitHub-generated URLs
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,4 +2,5 @@ title: Cayman theme
 description: Cayman is a clean, responsive theme for GitHub Pages.
 show_downloads: true
 google_analytics:
+google_tag: 
 theme: jekyll-theme-cayman

--- a/_includes/head-custom-google-analytics.html
+++ b/_includes/head-custom-google-analytics.html
@@ -8,3 +8,11 @@
     ga('send', 'pageview');
   </script>
 {% endif %}
+{% if site.google_tag %}
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{ site.google_tag }}');
+  </script>
+{% endif %}

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,6 +1,6 @@
 <!-- start custom head snippets, customize with your own _includes/head-custom.html file -->
 
-<!-- Setup Google Analytics -->
+<!-- Setup Google Analytics or GTM -->
 {% include head-custom-google-analytics.html %}
 
 <!-- You can set your favicon here -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,8 +25,7 @@
         <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
       {% endif %}
       {% if site.show_downloads %}
-        <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>
-        <a href="{{ site.github.tar_url }}" class="btn">Download .tar.gz</a>
+        <a href="{{ site.github.downloads_url }}" class="btn">Downloads</a>
       {% endif %}
     </header>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,9 @@
     {% include head-custom.html %}
   </head>
   <body>
+    {% if site.google_tag %}
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google_tag }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {% endif %}
     <a id="skip-to-content" href="#content">Skip to the content.</a>
 
     <header class="page-header" role="banner">

--- a/index.md
+++ b/index.md
@@ -98,7 +98,7 @@ end
 
 ### Large image
 
-![Branching](https://guides.github.com/activities/hello-world/branching.png)
+![Branching](https://docs.github.com/assets/cb-29151/images/help/desktop/squash-and-merge-selection.png)
 
 
 ### Definition lists can be used with HTML syntax.


### PR DESCRIPTION
Because Google's old UA analytics tracker is being phased out, and because Google Tag Manager is overall a better way to implement any kind of analytics tracker on your page, this adds a new site option `google_tag` which can be used instead of the existing `google_analytics` setting.

This should help future-proof analytics code for this theme.
