### PR TITLE
Image hosting fix

### DIFF
--- a/index.md
+++ b/index.md
@@ -98,7 +98,7 @@ end
 
 ### Large image
 
-![Branching](https://docs.github.com/assets/cb-36155/mw-1440/images/help/repository/file-tree-view-branch-dropdown-expanded.webp)
+![Branching](https://docs.github.com/assets/cb-23923/images/help/repository/branching.png)
 
 
 ### Definition lists can be used with HTML syntax.

--- a/index.md
+++ b/index.md
@@ -98,7 +98,7 @@ end
 
 ### Large image
 
-![Branching](https://guides.github.com/activities/hello-world/branching.png)
+![Branching](https://docs.github.com/assets/cb-36155/mw-1440/images/help/repository/file-tree-view-branch-dropdown-expanded.webp)
 
 
 ### Definition lists can be used with HTML syntax.


### PR DESCRIPTION
Updated the 404d image link on main page to reflect original image while still only linking to github's own internal data