### PR TITLE
Add docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Start from a light-weight ruby image
+FROM ruby:3.3.4-alpine
+
+# Install gcc, make and git
+RUN apk add build-base git
+
+# Update config
+ENV GEM_HOME=$HOME/gems PATH=$HOME/gems/bin:$PATH
+
+# Make directory for site
+WORKDIR /site
+
+# The Jekyll server runs on port 4000 by default
+EXPOSE 4000
+
+# Install jekyll and the required gems for the site
+COPY script/bootstrap /usr/local/bin
+COPY Gemfile Gemfile.lock jekyll-theme-cayman.gemspec /site/
+RUN bootstrap
+
+# Run jekyll-serve for dynamic development
+CMD [ "bundle", "exec", "jekyll", "serve", "--livereload", "--force_polling", "-H", "0.0.0.0", "-P", "4000"]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ If you'd like to preview the theme locally (for example, in the process of propo
 4. Run `bundle exec jekyll serve` to start the preview server
 5. Visit [`localhost:4000`](http://localhost:4000) in your browser to preview the theme
 
+### Previewing the theme via Docker
+
+We also provide a Docker image for easy local setup:
+
+1. Clone down the theme's repository (`git clone https://github.com/pages-themes/cayman`)
+2. `cd` into the theme's directory
+3. Run `docker compose up --build` to build and run the Docker image
+4. Visit [`localhost:4000`](http://localhost:4000) in your browser to preview the theme
+
 ### Running tests
 
 The theme contains a minimal test suite, to ensure a site with the theme would build successfully. To run the tests, simply run `script/cibuild`. You'll need to run `script/bootstrap` once before the test script will work.

--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,6 @@ description: Cayman is a clean, responsive theme for GitHub Pages.
 show_downloads: true
 google_analytics:
 theme: jekyll-theme-cayman
+exclude:
+  - Dockerfile
+  - docker-compose.yaml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+name: jekyll-theme-cayman-dev
+services:
+  jekyll-theme-cayman-dev:
+    build: .
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/site


### PR DESCRIPTION
This PR adds a Docker image, enabling local testing without the need to install ruby etc. locally:

1. Clone down the theme's repository (`git clone https://github.com/pages-themes/cayman`)
2. `cd` into the theme's directory
3. Run `docker compose up --build` to build and run the Docker image
4. Visit [`localhost:4000`](http://localhost:4000) in your browser to preview the theme